### PR TITLE
migrate lgtm

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,5 +40,14 @@ jobs:
       - run: cp -R cwl-temp cwlavro-generated/src/main/java/io/cwl/avro
       - run: echo "the output below should show that the generated API more-or-less matches the checked-in API for convenience"
       - run: git diff
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: java   
+
       - run: mvn -B clean install
 
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
**Description**
Enable CodeQL check (replacement for LGTM)
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

Will disable LGTM integration from the web console on merge

**Review Instructions**
See that recent builds have LGTM migrated checks
They should show up in https://github.com/dockstore/dockstore-cli/security/code-scanning

Issue
https://ucsc-cgl.atlassian.net/browse/SEAB-3011